### PR TITLE
Add vorbisfile to libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ append_gameplay_ext_lib(GAMEPLAY_LIBRARIES "BulletCollision" "bullet")
 append_gameplay_ext_lib(GAMEPLAY_LIBRARIES "LinearMath" "bullet")
 append_gameplay_ext_lib(GAMEPLAY_LIBRARIES "openal" "openal" "openal32")
 append_gameplay_ext_lib(GAMEPLAY_LIBRARIES "vorbis" "oggvorbis" "libvorbis")
-append_gameplay_ext_lib(GAMEPLAY_LIBRARIES "ogg" "oggvorbis" "libogg")
+append_gameplay_ext_lib(GAMEPLAY_LIBRARIES "ogg" "vorbisfile" "libogg")
 append_gameplay_ext_lib(GAMEPLAY_LIBRARIES "z" "zlib" "zlib")
 
 IF (TARGET_OS STREQUAL "LINUX")


### PR DESCRIPTION
On Arch Linux, I could not get make to link properly unless I added "vorbisfile" to GAMEPLAY_LIBRARIES.

I removed the second "oggvorbis" from the libraries and replaced it with vorbisfile. 

Also, I created an issue for this already and probably should have just put this pull request in. Sorry for the inconvenience. I'm pretty new at this.